### PR TITLE
Allow GUI executable test to run with real displays

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Sync dependencies
         run: uv sync --group build --group test
 
+      - name: Install Qt runtime libraries
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0
+
       - name: Run tests
         run: uv run pytest
 
@@ -61,6 +67,12 @@ jobs:
 
       - name: Sync dependencies
         run: uv sync --group build
+
+      - name: Install Qt runtime libraries
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0
 
       - name: Build executable with PyInstaller
         run: uv run python scripts/build_exe.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Guidelines
+
+- Running the GUI integration tests requires the system packages `libgl1`, `libegl1`, and `libxkbcommon-x11-0` to satisfy Qt's OpenGL dependencies.
+- Install these packages in CI or local environments before executing `uv run pytest` or launching the packaged executable tests.

--- a/src/how_many/app.py
+++ b/src/how_many/app.py
@@ -2,14 +2,16 @@
 
 from __future__ import annotations
 
+import os
+import traceback
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 import math
 import sys
 
 import numpy as np
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtGui, QtWidgets, QtTest
 
 APP_VERSION: str
 
@@ -640,6 +642,17 @@ class MainController(QtCore.QObject):
         super().__init__(None)
         self.app = app
         self.cfg = self._load_config()
+        self._selftest_active = bool(os.environ.get("HOW_MANY_SELFTEST"))
+        marker_env = os.environ.get("HOW_MANY_SELFTEST_MARKER")
+        self._selftest_marker: Optional[Path] = None
+        if marker_env:
+            try:
+                self._selftest_marker = Path(marker_env)
+            except Exception:
+                self._selftest_marker = None
+        self._selftest_triggered = False
+        self._selftest_exit_done = False
+        self._selftest_orig_excepthook: Optional[Callable[..., None]] = None
 
         # Compute virtual desktop rect (union of all screens)
         virt_rect = self._virtual_desktop_rect()
@@ -681,6 +694,98 @@ class MainController(QtCore.QObject):
 
         # Place control away from line
         self.ctrl.move(int(virt_rect.left() + 80), int(virt_rect.top() + 80))
+
+        if self._selftest_active:
+            self._selftest_setup()
+            QtCore.QTimer.singleShot(250, self._selftest_drive)
+            # Failsafe so the executable eventually exits even if the key event fails.
+            QtCore.QTimer.singleShot(5000, self._selftest_timeout)
+
+    def _selftest_drive(self) -> None:
+        if not self._selftest_active:
+            return
+
+        try:
+            target = self.overlay
+        except AttributeError:
+            return
+
+        if target is None:
+            return
+
+        target.activateWindow()
+        try:
+            target.raise_()
+        except Exception:
+            pass
+        target.setFocus(QtCore.Qt.FocusReason.OtherFocusReason)
+        QtTest.QTest.qWait(50)
+        QtTest.QTest.keyClick(target, QtCore.Qt.Key.Key_A)
+
+    def _selftest_setup(self) -> None:
+        if self._selftest_marker is not None:
+            try:
+                if self._selftest_marker.exists():
+                    self._selftest_marker.unlink()
+            except OSError:
+                pass
+        self._selftest_exit_done = False
+        self._selftest_orig_excepthook = sys.excepthook
+
+        def _excepthook(exc_type, exc, tb) -> None:
+            detail = "".join(traceback.format_exception(exc_type, exc, tb))
+            self._selftest_finish(success=False, exit_code=2, detail=detail)
+            if self._selftest_orig_excepthook is not None:
+                try:
+                    self._selftest_orig_excepthook(exc_type, exc, tb)
+                except Exception:
+                    pass
+
+        sys.excepthook = _excepthook
+        self.app.aboutToQuit.connect(self._selftest_restore_excepthook)
+
+    def _selftest_restore_excepthook(self) -> None:
+        if self._selftest_orig_excepthook is not None:
+            sys.excepthook = self._selftest_orig_excepthook
+            self._selftest_orig_excepthook = None
+
+    def _selftest_append_marker(self, text: str) -> None:
+        if self._selftest_marker is None:
+            return
+        try:
+            self._selftest_marker.parent.mkdir(parents=True, exist_ok=True)
+            with self._selftest_marker.open("a", encoding="utf-8") as fh:
+                fh.write(text)
+        except OSError:
+            pass
+
+    def _selftest_finish(self, *, success: bool, exit_code: int, detail: str = "") -> None:
+        if not self._selftest_active or self._selftest_exit_done:
+            return
+        self._selftest_exit_done = True
+        if success:
+            self._selftest_append_marker("selftest-ok\n")
+        else:
+            self._selftest_append_marker("selftest-error\n")
+            if detail:
+                if not detail.endswith("\n"):
+                    detail += "\n"
+                self._selftest_append_marker(detail)
+        self.app.exit(exit_code)
+
+    def _selftest_success(self) -> None:
+        if self._selftest_exit_done:
+            return
+        self._selftest_finish(success=True, exit_code=0)
+
+    def _selftest_timeout(self) -> None:
+        if self._selftest_exit_done:
+            return
+        self._selftest_finish(
+            success=False,
+            exit_code=3,
+            detail="Self-test timeout waiting for analyze shortcut.",
+        )
 
     # ---------------------------- Config I/O ----------------------------------
 
@@ -734,6 +839,11 @@ class MainController(QtCore.QObject):
 
     def analyze(self) -> None:
         """Capture stripe under the overlay line, estimate counts, update UI."""
+        if self._selftest_active and not self._selftest_triggered:
+            self._selftest_triggered = True
+            self._selftest_append_marker("analyze-called\n")
+            QtCore.QTimer.singleShot(50, self._selftest_success)
+
         L = self.overlay.line_length()
         if L < self.cfg.params.min_length_px:
             self.ctrl.set_status(

--- a/tests/test_executable_selftest.py
+++ b/tests/test_executable_selftest.py
@@ -57,9 +57,11 @@ def test_pyinstaller_executable_handles_analyze(tmp_path: Path) -> None:
     if sys.platform.startswith("linux"):
         missing_packages = _missing_linux_packages()
         if missing_packages:
-            pytest.skip(
+            pytest.fail(
                 "Missing system packages required for Qt: "
                 + ", ".join(sorted(missing_packages))
+                + ". Install them with "
+                "`sudo apt-get update && sudo apt-get install libegl1 libgl1 libxkbcommon-x11-0`."
             )
 
     subprocess.run([sys.executable, str(build_script)], check=True, cwd=project_root)

--- a/tests/test_executable_selftest.py
+++ b/tests/test_executable_selftest.py
@@ -1,0 +1,71 @@
+"""End-to-end test for the packaged how_many executable."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+def test_pyinstaller_executable_handles_analyze(tmp_path: Path) -> None:
+    """Build the PyInstaller bundle and ensure the analyze shortcut fires in self-test mode."""
+
+    project_root = Path(__file__).resolve().parents[1]
+    build_script = project_root / "scripts" / "build_exe.py"
+
+    subprocess.run([sys.executable, str(build_script)], check=True, cwd=project_root)
+
+    exe_name = "how_many.exe" if sys.platform.startswith("win") else "how_many"
+    exe_path = project_root / "dist" / exe_name
+    assert exe_path.exists(), f"Expected executable at {exe_path}" 
+
+    marker_path = tmp_path / "selftest-marker.txt"
+
+    env = os.environ.copy()
+    env["HOW_MANY_SELFTEST"] = "1"
+    env["HOW_MANY_SELFTEST_MARKER"] = str(marker_path)
+    env.setdefault("QT_OPENGL", "software")
+    if sys.platform.startswith("linux"):
+        if not env.get("DISPLAY") and not env.get("WAYLAND_DISPLAY"):
+            env.setdefault("QT_QPA_PLATFORM", "offscreen")
+        env.setdefault("XDG_RUNTIME_DIR", str(tmp_path))
+    elif sys.platform == "darwin":
+        if env.get("CI") or env.get("GITHUB_ACTIONS"):
+            env.setdefault("QT_QPA_PLATFORM", "offscreen")
+    else:
+        env.setdefault("QT_QPA_PLATFORM", env.get("QT_QPA_PLATFORM", "windows"))
+
+    try:
+        completed = subprocess.run(
+            [str(exe_path)],
+            cwd=project_root,
+            env=env,
+            check=False,
+            timeout=30,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        pytest.fail(
+            "Executable timed out during self-test."
+            + (f"\nSTDOUT:\n{stdout}" if stdout else "")
+            + (f"\nSTDERR:\n{stderr}" if stderr else "")
+        )
+
+    if completed.returncode != 0:
+        pytest.fail(
+            f"Executable exited with code {completed.returncode}."
+            + (f"\nSTDOUT:\n{completed.stdout}" if completed.stdout else "")
+            + (f"\nSTDERR:\n{completed.stderr}" if completed.stderr else "")
+        )
+
+    assert marker_path.exists(), "Self-test marker file was not created"
+    contents = marker_path.read_text(encoding="utf-8")
+    assert "analyze-called" in contents, contents
+    assert "selftest-ok" in contents, contents
+    assert "selftest-error" not in contents, contents


### PR DESCRIPTION
## Summary
- allow the executable smoke test to use the default Qt platform plugin when a display is available, only forcing offscreen mode in headless environments
- document the required libgl1, libegl1, and libxkbcommon-x11-0 system packages for GUI tests in AGENTS.md

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a11df73883259f2168a30739aed6