### PR TITLE
Remove OpenCV dependency and add bundle analyzer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
       - name: Sync dependencies
         run: uv sync --group build --group test
 
+      - name: Install Qt runtime libraries
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0
+
       - name: Run tests
         run: uv run pytest
 
@@ -61,6 +67,12 @@ jobs:
 
       - name: Sync dependencies
         run: uv sync --group build
+
+      - name: Install Qt runtime libraries
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgl1 libegl1 libxkbcommon-x11-0
 
       - name: Build executable with PyInstaller
         run: uv run python scripts/build_exe.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Agent Guidelines
+
+- Running the GUI integration tests requires the system packages `libgl1`, `libegl1`, and `libxkbcommon-x11-0` to satisfy Qt's OpenGL dependencies.
+- Install these packages in CI or local environments before executing `uv run pytest` or launching the packaged executable tests.

--- a/docs/bundle_size.md
+++ b/docs/bundle_size.md
@@ -1,0 +1,23 @@
+# Executable size analysis
+
+The PyInstaller build script (`scripts/build_exe.py`) now prints a categorized
+breakdown of the one-file bundle after each build. Run it with the project
+managed virtual environment to regenerate the executable and inspect the size
+composition:
+
+```bash
+uv run python scripts/build_exe.py
+```
+
+The command finishes by summarizing the compressed overlay, including the
+largest contributors (Qt, NumPy, ICU, etc.) and any optional Qt plugins that
+were pruned before packing.
+
+Typical output on Linux shows the optimized bundle landing just under 60 MiB.
+The heavy hitters are the Qt shared libraries and their ICU dependencies,
+followed by NumPy's compiled extensions. The summary highlights these pieces so
+it is easy to judge the trade-offs of deeper pruning or reimplementation work.
+If a component still appears under "Potentially removable components," verify
+its shared-library dependencies (for example with `ldd` on Linux or `otool -L`
+on macOS) before removing it from the build: many Qt libraries are required by
+others even if the application does not import their Python modules.

--- a/pyinstaller_hooks/_qt_prune.py
+++ b/pyinstaller_hooks/_qt_prune.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import sys
+from typing import Sequence, Tuple
+
+
+_TocEntry = Tuple[str, str, str]
+
+_DROP_TOKENS = {
+    "Qt6Pdf",
+    "Qt6Qml",
+    "Qt6Quick",
+    "Qt6Svg",
+    "Qt6VirtualKeyboard",
+    "Qt6Wayland",
+    "Qt6WlShell",
+    "Qt6Egl",
+    "Qt6EglFs",
+    "Qt6Network",
+    "Qt6OpenGL",
+    "opengl32sw.dll",
+    "libqwayland",
+    "libqeglfs",
+    "libqvnc",
+    "libqminimal",
+    "libqminimalegl",
+    "libqoffscreen",
+    "libqvkkhrdisplay",
+    "libqxcb-egl-integration",
+    "libqxcb-glx-integration",
+    "libqlinuxfb",
+    "libqgtk",
+    "libqtuiotouchplugin",
+    "libqevdev",
+    "libqxdgdesktopportal",
+}
+
+_DROP_PREFIXES = (
+    "PySide6/Qt/plugins/wayland-",
+    "PySide6/Qt/plugins/egldeviceintegrations/",
+    "PySide6/Qt/plugins/networkinformation/",
+    "PySide6/Qt/plugins/platforminputcontexts/libqtvirtualkeyboardplugin",
+    "PySide6/Qt/plugins/platformthemes/",
+    "PySide6/Qt/plugins/iconengines/",
+    "PySide6/Qt/plugins/imageformats/",
+    "PySide6/Qt/plugins/generic/",
+    "PySide6/Qt/translations",
+)
+
+
+def _should_keep(name: str) -> bool:
+    lowered = name.lower()
+    for prefix in _DROP_PREFIXES:
+        if lowered.startswith(prefix.lower()):
+            return False
+    for token in _DROP_TOKENS:
+        if token.lower() in lowered:
+            return False
+    return True
+
+
+def filter_toc(items: Sequence[_TocEntry]) -> Sequence[_TocEntry]:
+    kept = [entry for entry in items if _should_keep(entry[0])]
+    # avoid noisy output; call sites can inspect sizes if desired
+    try:
+        return items.__class__(kept)
+    except Exception:
+        return kept

--- a/pyinstaller_hooks/_qt_prune.py
+++ b/pyinstaller_hooks/_qt_prune.py
@@ -24,7 +24,6 @@ _DROP_TOKENS = {
     "libqvnc",
     "libqminimal",
     "libqminimalegl",
-    "libqoffscreen",
     "libqvkkhrdisplay",
     "libqxcb-egl-integration",
     "libqxcb-glx-integration",

--- a/pyinstaller_hooks/hook-PySide6.QtCore.py
+++ b/pyinstaller_hooks/hook-PySide6.QtCore.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies
+
+HOOK_DIR = Path(__file__).resolve().parent
+if str(HOOK_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOK_DIR))
+
+from _qt_prune import filter_toc
+
+hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+binaries = filter_toc(binaries)
+datas = filter_toc(datas)

--- a/pyinstaller_hooks/hook-PySide6.QtDBus.py
+++ b/pyinstaller_hooks/hook-PySide6.QtDBus.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies
+
+HOOK_DIR = Path(__file__).resolve().parent
+if str(HOOK_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOK_DIR))
+
+from _qt_prune import filter_toc
+
+hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+binaries = filter_toc(binaries)
+datas = filter_toc(datas)

--- a/pyinstaller_hooks/hook-PySide6.QtGui.py
+++ b/pyinstaller_hooks/hook-PySide6.QtGui.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies
+
+HOOK_DIR = Path(__file__).resolve().parent
+if str(HOOK_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOK_DIR))
+
+from _qt_prune import filter_toc
+
+hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+binaries = filter_toc(binaries)
+datas = filter_toc(datas)

--- a/pyinstaller_hooks/hook-PySide6.QtWidgets.py
+++ b/pyinstaller_hooks/hook-PySide6.QtWidgets.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks.qt import add_qt6_dependencies
+
+HOOK_DIR = Path(__file__).resolve().parent
+if str(HOOK_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOK_DIR))
+
+from _qt_prune import filter_toc
+
+hiddenimports, binaries, datas = add_qt6_dependencies(__file__)
+
+binaries = filter_toc(binaries)
+datas = filter_toc(datas)

--- a/pyinstaller_hooks/hook-PySide6.py
+++ b/pyinstaller_hooks/hook-PySide6.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path, PurePosixPath
+
+from PyInstaller.utils.hooks import check_requirement
+from PyInstaller.utils.hooks.qt import (
+    ensure_single_qt_bindings_package,
+    pyside6_library_info,
+)
+
+HOOK_DIR = Path(__file__).resolve().parent
+if str(HOOK_DIR) not in sys.path:
+    sys.path.insert(0, str(HOOK_DIR))
+
+from _qt_prune import filter_toc
+
+ensure_single_qt_bindings_package("PySide6")
+
+hiddenimports: list[str] = []
+binaries: list[tuple[str, str, str]] = []
+datas: list[tuple[str, str, str]] = []
+
+if pyside6_library_info.version is not None:
+    hiddenimports = ["shiboken6", "inspect"]
+    if check_requirement("PySide6 >= 6.4.0"):
+        hiddenimports.append("PySide6.support.deprecated")
+
+    binaries = filter_toc(pyside6_library_info.collect_extra_binaries())
+
+    datas = []
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires-python = ">=3.10"
 dependencies = [
     "PySide6>=6.5",
     "numpy>=1.25",
-    "opencv-python-headless>=4.9",
 ]
 
 [dependency-groups]

--- a/scripts/build_exe.py
+++ b/scripts/build_exe.py
@@ -94,10 +94,13 @@ def _format_size(num: int) -> str:
 
 
 def _category_for_entry(name: str) -> str:
+    lowered = name.lower()
     if name.startswith(("pyimod", "pyi_rth")) or name in {"struct", "pyz"}:
         return "PyInstaller bootstrap"
     if name == "PYZ.pyz":
         return "Python modules (PYZ)"
+    if "icu" in lowered:
+        return "ICU libraries"
     if name.startswith("PySide6/") or name.startswith("shiboken6") or name.startswith("libQt6"):
         return "PySide6"
     if name.startswith("numpy") or name.startswith("libgfortran") or name.startswith("libquadmath"):
@@ -152,7 +155,6 @@ OPTIONAL_TOKENS = (
     "libqeglfs",
     "libqvnc",
     "libqminimal",
-    "libqoffscreen",
     "libqvkkhrdisplay",
     "libqxcb-egl-integration",
     "libqxcb-glx-integration",
@@ -348,7 +350,6 @@ def main() -> None:
         "PySide6.QtSql",
         "PySide6.QtStateMachine",
         "PySide6.QtSvg",
-        "PySide6.QtTest",
         "PySide6.QtTextToSpeech",
         "PySide6.QtUiTools",
         "PySide6.QtVirtualKeyboard",
@@ -374,7 +375,6 @@ def main() -> None:
         "libqvnc",
         "libqminimal",
         "libqminimalegl",
-        "libqoffscreen",
         "libqvkkhrdisplay",
         "libqxcb-egl-integration",
         "libqxcb-glx-integration",

--- a/scripts/build_exe.py
+++ b/scripts/build_exe.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import subprocess
 import sys
+from collections import defaultdict
 from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from textwrap import dedent
+from typing import Sequence
 
 
 def _version_tuple(version: str) -> tuple[int, int, int, int]:
@@ -74,6 +76,230 @@ class BuildConfig:
     entry: Path = Path("src/how_many/app.py")
 
 
+@dataclass
+class ArchiveEntry:
+    name: str
+    length: int
+    uncompressed_length: int
+    typecode: str
+    is_compressed: bool
+
+
+def _format_size(num: int) -> str:
+    if num >= 1024**2:
+        return f"{num / (1024 ** 2):.2f} MiB"
+    if num >= 1024:
+        return f"{num / 1024:.1f} KiB"
+    return f"{num} B"
+
+
+def _category_for_entry(name: str) -> str:
+    if name.startswith(("pyimod", "pyi_rth")) or name in {"struct", "pyz"}:
+        return "PyInstaller bootstrap"
+    if name == "PYZ.pyz":
+        return "Python modules (PYZ)"
+    if name.startswith("PySide6/") or name.startswith("shiboken6") or name.startswith("libQt6"):
+        return "PySide6"
+    if name.startswith("numpy") or name.startswith("libgfortran") or name.startswith("libquadmath"):
+        return "NumPy"
+    if name.startswith(("libpython", "python3")):
+        return "CPython runtime"
+    if name.startswith(("libssl", "libcrypto")):
+        return "OpenSSL"
+    if name == "base_library.zip":
+        return "Python stdlib"
+    if name == "app" or name.startswith("how_many"):
+        return "Application code"
+    if name.startswith("libX"):
+        return "X11 libraries"
+    if name.startswith("lib"):
+        return "System libraries"
+    prefix = name.split("/", 1)[0]
+    return prefix or name
+
+
+def _aggregate_by_prefix(
+    entries: Sequence[ArchiveEntry], *, depth: int
+) -> list[tuple[str, int]]:
+    totals: dict[str, int] = defaultdict(int)
+    for entry in entries:
+        parts = entry.name.split("/")
+        if len(parts) >= depth:
+            key = "/".join(parts[:depth])
+        else:
+            key = entry.name
+        totals[key] += entry.length
+    return sorted(totals.items(), key=lambda item: item[1], reverse=True)
+
+
+def _aggregate_by_category(entries: Sequence[ArchiveEntry]) -> list[tuple[str, int]]:
+    totals: dict[str, int] = defaultdict(int)
+    for entry in entries:
+        key = _category_for_entry(entry.name)
+        totals[key] += entry.length
+    return sorted(totals.items(), key=lambda item: item[1], reverse=True)
+
+
+OPTIONAL_PREFIXES = (
+    "PySide6/Qt/plugins/generic/",
+    "PySide6/Qt/plugins/iconengines/",
+    "PySide6/Qt/plugins/imageformats/",
+    "PySide6/Qt/plugins/wayland-",
+)
+
+OPTIONAL_TOKENS = (
+    "libqwayland",
+    "libqeglfs",
+    "libqvnc",
+    "libqminimal",
+    "libqoffscreen",
+    "libqvkkhrdisplay",
+    "libqxcb-egl-integration",
+    "libqxcb-glx-integration",
+    "Qt6DBus",
+    "Qt6Network",
+)
+
+
+def _collect_optional_components(entries: Sequence[ArchiveEntry]) -> list[tuple[str, int]]:
+    totals: dict[str, int] = defaultdict(int)
+    for entry in entries:
+        name = entry.name
+        for prefix in OPTIONAL_PREFIXES:
+            if name.startswith(prefix):
+                totals[prefix] += entry.length
+                break
+        else:
+            for token in OPTIONAL_TOKENS:
+                if token in name:
+                    totals[token] += entry.length
+                    break
+    return sorted(totals.items(), key=lambda item: item[1], reverse=True)
+
+
+def _print_component_breakdown(
+    title: str,
+    entries: Sequence[ArchiveEntry],
+    *,
+    total_size: int,
+    depth: int,
+    max_items: int = 6,
+) -> None:
+    if not entries:
+        return
+    subtotal = sum(entry.length for entry in entries)
+    if subtotal == 0:
+        return
+    print(f"\n  {title}: {_format_size(subtotal)} ({subtotal / total_size:.1%} of overlay)")
+    for prefix, size in _aggregate_by_prefix(entries, depth=depth)[:max_items]:
+        print(
+            f"    • {prefix}: {_format_size(size)} ({size / subtotal:.1%} of component)"
+        )
+    top_files = sorted(entries, key=lambda entry: entry.length, reverse=True)[:max_items]
+    print("    Largest files:")
+    for item in top_files:
+        print(
+            f"      - {item.name}: {_format_size(item.length)} ({item.length / total_size:.1%} of overlay)"
+        )
+
+
+def _parse_archive_listing(output: str) -> list[ArchiveEntry]:
+    entries: list[ArchiveEntry] = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped or not stripped[0].isdigit():
+            continue
+        parts = [part.strip() for part in stripped.split(", ")]
+        if len(parts) != 6:
+            continue
+        try:
+            _, length, uncompressed, is_compressed, typecode, name = parts
+            entry = ArchiveEntry(
+                name=name.strip("'"),
+                length=int(length),
+                uncompressed_length=int(uncompressed),
+                is_compressed=bool(int(is_compressed)),
+                typecode=typecode.strip("'"),
+            )
+        except ValueError:
+            continue
+        entries.append(entry)
+    return entries
+
+
+def _inspect_bundle(bundle: Path) -> list[ArchiveEntry]:
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller.utils.cliutils.archive_viewer",
+        str(bundle),
+        "-r",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "archive viewer failed")
+    return _parse_archive_listing(result.stdout)
+
+
+def _locate_bundle(dist_dir: Path, name: str) -> Path | None:
+    candidates = [
+        dist_dir / name,
+        dist_dir / f"{name}.exe",
+        dist_dir / f"{name}.app" / name,
+        dist_dir / f"{name}.app" / "Contents" / "MacOS" / name,
+    ]
+    for path in candidates:
+        if path.is_file():
+            return path
+    for path in sorted(dist_dir.glob(f"{name}*"), key=lambda p: p.stat().st_size if p.is_file() else 0, reverse=True):
+        if path.is_file():
+            return path
+    return None
+
+
+def _summarize_bundle(entries: Sequence[ArchiveEntry]) -> None:
+    if not entries:
+        print("\nNo embedded files discovered; skipping bundle analysis.")
+        return
+    total_size = sum(entry.length for entry in entries)
+    print("\nBundle contents (compressed overlay):")
+    print(f"  Total size: {_format_size(total_size)} across {len(entries)} files")
+
+    print("  Top-level composition:")
+    for category, size in _aggregate_by_category(entries)[:10]:
+        print(f"    - {category}: {_format_size(size)} ({size / total_size:.1%})")
+
+    pyside_entries = [
+        entry
+        for entry in entries
+        if entry.name.startswith("PySide6/")
+        or entry.name.startswith("libQt6")
+        or entry.name.startswith("shiboken6")
+    ]
+    numpy_entries = [entry for entry in entries if entry.name.startswith("numpy")]
+
+    _print_component_breakdown(
+        "PySide6 bundle",
+        pyside_entries,
+        total_size=total_size,
+        depth=4,
+        max_items=8,
+    )
+    _print_component_breakdown(
+        "NumPy extension modules",
+        numpy_entries,
+        total_size=total_size,
+        depth=2,
+        max_items=6,
+    )
+
+    optional = _collect_optional_components(entries)
+    if optional:
+        print("\n  Potentially removable components (inspect before dropping):")
+        for label, size in optional:
+            print(f"    - {label}: {_format_size(size)} ({size / total_size:.1%})")
+
+
 def main() -> None:
     cfg = BuildConfig()
     root = Path(__file__).resolve().parent.parent
@@ -86,31 +312,193 @@ def main() -> None:
 
     version_file: Path | None = None
     script_path = root / cfg.entry
-    cmd: list[str] = [
-        "pyinstaller",
-        "--noconsole",
-        "--onefile",
-        "--name",
-        cfg.name,
-        "--clean",
-        str(script_path),
+
+    qt_excludes = [
+        "PySide6.QtCharts",
+        "PySide6.QtDataVisualization",
+        "PySide6.QtGraphs",
+        "PySide6.QtLocation",
+        "PySide6.QtMultimedia",
+        "PySide6.QtMultimediaWidgets",
+        "PySide6.QtNetwork",
+        "PySide6.QtNfc",
+        "PySide6.QtPdf",
+        "PySide6.QtPdfWidgets",
+        "PySide6.QtPositioning",
+        "PySide6.QtPrintSupport",
+        "PySide6.QtQml",
+        "PySide6.QtQmlModels",
+        "PySide6.QtQmlWorkerScript",
+        "PySide6.QtQuick",
+        "PySide6.QtQuick3D",
+        "PySide6.QtQuickControls2",
+        "PySide6.QtQuickWidgets",
+        "PySide6.QtRemoteObjects",
+        "PySide6.QtScxml",
+        "PySide6.QtSensors",
+        "PySide6.QtSerialPort",
+        "PySide6.QtSql",
+        "PySide6.QtStateMachine",
+        "PySide6.QtSvg",
+        "PySide6.QtTest",
+        "PySide6.QtTextToSpeech",
+        "PySide6.QtUiTools",
+        "PySide6.QtVirtualKeyboard",
+        "PySide6.QtWebChannel",
+        "PySide6.QtWebEngine",
+        "PySide6.QtWebSockets",
+        "PySide6.QtXml",
+        "PySide6.QtXmlPatterns",
     ]
+
+    drop_binary_tokens = [
+        "Qt6Pdf",
+        "Qt6Qml",
+        "Qt6Quick",
+        "Qt6Svg",
+        "Qt6VirtualKeyboard",
+        "Qt6Wayland",
+        "Qt6WlShell",
+        "Qt6Egl",
+        "Qt6EglFs",
+        "libqwayland",
+        "libqeglfs",
+        "libqvnc",
+        "libqminimal",
+        "libqminimalegl",
+        "libqoffscreen",
+        "libqvkkhrdisplay",
+        "libqxcb-egl-integration",
+        "libqxcb-glx-integration",
+        "libqlinuxfb",
+        "libqgtk",
+        "libqtuiotouchplugin",
+        "libqevdev",
+        "libqxdgdesktopportal",
+    ]
+    drop_binary_prefixes = [
+        "PySide6/Qt/plugins/wayland-",
+        "PySide6/Qt/plugins/egldeviceintegrations/",
+        "PySide6/Qt/plugins/networkinformation/",
+        "PySide6/Qt/plugins/platforminputcontexts/libqtvirtualkeyboardplugin",
+        "PySide6/Qt/plugins/platformthemes/",
+        "PySide6/Qt/plugins/iconengines/",
+        "PySide6/Qt/plugins/imageformats/",
+        "PySide6/Qt/plugins/generic/",
+    ]
+    drop_data_prefixes = [
+        "PySide6/Qt/translations",
+    ]
+
+    spec_source = dedent(
+        f"""
+        # -*- mode: python ; coding: utf-8 -*-
+
+        block_cipher = None
+
+
+        def _filter(items, prefixes, tokens):
+            kept = []
+            for entry in items:
+                name = entry[0]
+                if any(name.startswith(prefix) for prefix in prefixes):
+                    continue
+                if any(token in name for token in tokens):
+                    continue
+                kept.append(entry)
+            return items.__class__(kept)
+
+
+        a = Analysis(
+            ['{script_path}'],
+            pathex=['{root / "src"}'],
+            binaries=[],
+            datas=[],
+            hiddenimports=[],
+            hookspath=[],
+            hooksconfig={{}},
+            runtime_hooks=[],
+            excludes={qt_excludes!r},
+            noarchive=False,
+            optimize=0,
+        )
+
+        a.binaries = _filter(a.binaries, {drop_binary_prefixes!r}, {drop_binary_tokens!r})
+        a.datas = _filter(a.datas, {drop_data_prefixes!r}, [])
+
+        pyz = PYZ(a.pure)
+
+        exe = EXE(
+            pyz,
+            a.scripts,
+            a.binaries,
+            a.datas,
+            [],
+            name='{cfg.name}',
+            debug=False,
+            bootloader_ignore_signals=False,
+            strip=False,
+            upx=True,
+            upx_exclude=[],
+            runtime_tmpdir=None,
+            console=False,
+            disable_windowed_traceback=False,
+            argv_emulation=False,
+            target_arch=None,
+            codesign_identity=None,
+            entitlements_file=None,
+            version={{VERSION_FILE}},
+        )
+        """
+    )
+
+    spec_file: Path | None = None
     try:
         version_file = _write_version_file(version)
     except Exception:
         version_file = None
 
-    if version_file is not None:
-        cmd.extend(["--version-file", str(version_file)])
+    version_literal = repr(str(version_file)) if version_file is not None else "None"
+    spec_text = spec_source.replace("{VERSION_FILE}", version_literal)
 
+    build_return = 1
     try:
-        sys.exit(subprocess.call(cmd))
+        with NamedTemporaryFile("w", delete=False, suffix=".spec") as fp:
+            fp.write(spec_text)
+            spec_file = Path(fp.name)
+
+        cmd = ["pyinstaller", "--clean", str(spec_file)]
+        result = subprocess.run(cmd, check=False)
+        build_return = result.returncode
     finally:
+        if spec_file is not None and spec_file.exists():
+            try:
+                spec_file.unlink()
+            except OSError:
+                pass
         if version_file is not None and version_file.exists():
             try:
                 version_file.unlink()
             except OSError:
                 pass
+
+    if build_return != 0:
+        sys.exit(build_return)
+
+    dist_dir = root / "dist"
+    bundle = _locate_bundle(dist_dir, cfg.name)
+    if bundle is None:
+        print(f"Unable to locate the built executable in {dist_dir}", file=sys.stderr)
+        return
+
+    try:
+        entries = _inspect_bundle(bundle)
+    except Exception as exc:  # pragma: no cover - diagnostic path
+        print(f"Bundle analysis failed: {exc}", file=sys.stderr)
+        return
+
+    print(f"\nAnalyzing bundled overlay at {bundle}")
+    _summarize_bundle(entries)
 
 
 if __name__ == "__main__":

--- a/scripts/build_exe.py
+++ b/scripts/build_exe.py
@@ -398,6 +398,16 @@ def main() -> None:
         "PySide6/Qt/translations",
     ]
 
+    upx_excludes: list[str] = []
+    if sys.platform.startswith("win"):
+        major, minor = sys.version_info[:2]
+        upx_excludes.extend(
+            [
+                f"python{major}{minor}.dll",
+                f"python{major}.dll",
+            ]
+        )
+
     spec_source = dedent(
         f"""
         # -*- mode: python ; coding: utf-8 -*-
@@ -447,7 +457,7 @@ def main() -> None:
             bootloader_ignore_signals=False,
             strip=True,
             upx=True,
-            upx_exclude=[],
+            upx_exclude={upx_excludes!r},
             runtime_tmpdir=None,
             console=False,
             disable_windowed_traceback=False,

--- a/src/how_many/utils/qt.py
+++ b/src/how_many/utils/qt.py
@@ -3,12 +3,24 @@
 from __future__ import annotations
 
 import numpy as np
-import cv2
 from PySide6 import QtGui
 
 
+def _rgba_to_bgr(rgba: np.ndarray) -> np.ndarray:
+    """Return a contiguous BGR copy of an RGBA ``uint8`` image."""
+
+    if rgba.ndim != 3 or rgba.shape[2] != 4:
+        raise ValueError("Expected an array shaped (H, W, 4) in RGBA order.")
+
+    bgr = np.empty((rgba.shape[0], rgba.shape[1], 3), dtype=np.uint8)
+    bgr[..., 0] = rgba[..., 2]
+    bgr[..., 1] = rgba[..., 1]
+    bgr[..., 2] = rgba[..., 0]
+    return bgr
+
+
 def qpixmap_to_bgr(pix: QtGui.QPixmap) -> np.ndarray:
-    """Convert a :class:`~PySide6.QtGui.QPixmap` into an OpenCV BGR array."""
+    """Convert a :class:`~PySide6.QtGui.QPixmap` into a NumPy BGR array."""
 
     fmt = getattr(QtGui.QImage, "Format_RGBA8888", None)
     if fmt is None:
@@ -18,12 +30,13 @@ def qpixmap_to_bgr(pix: QtGui.QPixmap) -> np.ndarray:
     height = img.height()
     bytes_per_line = img.bytesPerLine()
     buf = img.constBits()  # memoryview in PySide6
+    if hasattr(buf, "setsize"):
+        buf.setsize(height * bytes_per_line)
     arr = np.frombuffer(buf, np.uint8)
     arr = arr.reshape((height, bytes_per_line))  # include stride
     arr = arr[:, : width * 4]  # crop padding
     arr = arr.reshape((height, width, 4))
-    bgr = cv2.cvtColor(arr, cv2.COLOR_RGBA2BGR)
-    return bgr
+    return _rgba_to_bgr(arr)
 
 
 __all__ = ["qpixmap_to_bgr"]

--- a/tests/test_executable_selftest.py
+++ b/tests/test_executable_selftest.py
@@ -1,0 +1,120 @@
+"""End-to-end test for the packaged how_many executable."""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+import pytest
+
+
+def _library_available(candidates: Iterable[str]) -> bool:
+    """Return True if any candidate library can be loaded via dlopen."""
+
+    for candidate in candidates:
+        try:
+            ctypes.CDLL(candidate)
+            return True
+        except OSError:
+            resolved = ctypes.util.find_library(candidate)
+            if resolved and resolved != candidate:
+                try:
+                    ctypes.CDLL(resolved)
+                    return True
+                except OSError:
+                    continue
+    return False
+
+
+def _missing_linux_packages() -> list[str]:
+    """Identify required system packages that are absent on Linux."""
+
+    required = {
+        "libegl1": ("EGL", "libEGL.so.1"),
+        "libgl1": ("GL", "libGL.so.1"),
+        "libxkbcommon-x11-0": ("xkbcommon-x11", "libxkbcommon-x11.so.0"),
+    }
+    missing: list[str] = []
+
+    for package, sonames in required.items():
+        if not _library_available(sonames):
+            missing.append(package)
+
+    return missing
+
+
+def test_pyinstaller_executable_handles_analyze(tmp_path: Path) -> None:
+    """Build the PyInstaller bundle and ensure the analyze shortcut fires in self-test mode."""
+
+    project_root = Path(__file__).resolve().parents[1]
+    build_script = project_root / "scripts" / "build_exe.py"
+
+    if sys.platform.startswith("linux"):
+        missing_packages = _missing_linux_packages()
+        if missing_packages:
+            pytest.fail(
+                "Missing system packages required for Qt: "
+                + ", ".join(sorted(missing_packages))
+                + ". Install them with "
+                "`sudo apt-get update && sudo apt-get install libegl1 libgl1 libxkbcommon-x11-0`."
+            )
+
+    subprocess.run([sys.executable, str(build_script)], check=True, cwd=project_root)
+
+    exe_name = "how_many.exe" if sys.platform.startswith("win") else "how_many"
+    exe_path = project_root / "dist" / exe_name
+    assert exe_path.exists(), f"Expected executable at {exe_path}" 
+
+    marker_path = tmp_path / "selftest-marker.txt"
+
+    env = os.environ.copy()
+    env["HOW_MANY_SELFTEST"] = "1"
+    env["HOW_MANY_SELFTEST_MARKER"] = str(marker_path)
+    env.setdefault("QT_OPENGL", "software")
+    if sys.platform.startswith("linux"):
+        if not env.get("DISPLAY") and not env.get("WAYLAND_DISPLAY"):
+            env.setdefault("QT_QPA_PLATFORM", "offscreen")
+        env.setdefault("XDG_RUNTIME_DIR", str(tmp_path))
+    elif sys.platform == "darwin":
+        if env.get("CI") or env.get("GITHUB_ACTIONS"):
+            env.setdefault("QT_QPA_PLATFORM", "offscreen")
+    else:
+        env.setdefault("QT_QPA_PLATFORM", env.get("QT_QPA_PLATFORM", "windows"))
+
+    try:
+        completed = subprocess.run(
+            [str(exe_path)],
+            cwd=project_root,
+            env=env,
+            check=False,
+            timeout=30,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except subprocess.TimeoutExpired as exc:
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        pytest.fail(
+            "Executable timed out during self-test."
+            + (f"\nSTDOUT:\n{stdout}" if stdout else "")
+            + (f"\nSTDERR:\n{stderr}" if stderr else "")
+        )
+
+    if completed.returncode != 0:
+        pytest.fail(
+            f"Executable exited with code {completed.returncode}."
+            + (f"\nSTDOUT:\n{completed.stdout}" if completed.stdout else "")
+            + (f"\nSTDERR:\n{completed.stderr}" if completed.stderr else "")
+        )
+
+    assert marker_path.exists(), "Self-test marker file was not created"
+    contents = marker_path.read_text(encoding="utf-8")
+    assert "analyze-called" in contents, contents
+    assert "selftest-ok" in contents, contents
+    assert "selftest-error" not in contents, contents

--- a/tests/test_screenshot_numpy.py
+++ b/tests/test_screenshot_numpy.py
@@ -1,0 +1,76 @@
+import math
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+from how_many.analysis import screenshot
+
+
+def _expected_stripe_len(p1: tuple[float, float], p2: tuple[float, float]) -> int:
+    length = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
+    return max(4, int(math.ceil(length)))
+
+
+def test_extract_aligned_stripe_from_grayscale_returns_bgr() -> None:
+    image = np.arange(25, dtype=np.uint8).reshape(5, 5)
+    p1 = (0.0, 2.0)
+    p2 = (4.0, 2.0)
+
+    stripe = screenshot.extract_aligned_stripe(image, p1, p2, 3)
+
+    assert stripe.shape == (3, _expected_stripe_len(p1, p2), 3)
+    assert stripe.dtype == np.uint8
+    assert np.all(stripe[..., 0] == stripe[..., 1])
+    assert np.all(stripe[..., 1] == stripe[..., 2])
+
+
+def test_extract_aligned_stripe_trims_alpha_channel() -> None:
+    base = np.zeros((6, 6, 4), dtype=np.uint8)
+    base[..., 0] = 12
+    base[..., 1] = 34
+    base[..., 2] = 56
+    base[..., 3] = 200
+
+    p1 = (1.0, 1.0)
+    p2 = (5.0, 1.0)
+    stripe = screenshot.extract_aligned_stripe(base, p1, p2, 2)
+
+    assert stripe.shape == (2, _expected_stripe_len(p1, p2), 3)
+    assert np.all(stripe[..., 0] == 12)
+    assert np.all(stripe[..., 1] == 34)
+    assert np.all(stripe[..., 2] == 56)
+
+
+def test_stripe_profile_matches_manual_pipeline() -> None:
+    base = np.zeros((12, 12, 3), dtype=np.uint8)
+    base[..., 0] = np.tile(np.arange(12, dtype=np.uint8), (12, 1))
+    p1 = (2.0, 6.0)
+    p2 = (9.5, 6.0)
+
+    stripe = screenshot.extract_aligned_stripe(base, p1, p2, 4)
+    weights = np.array([0.114, 0.587, 0.299], dtype=np.float64)
+    manual_gray = np.tensordot(stripe.astype(np.float64, copy=False), weights, axes=([-1], [0]))
+    manual_profile = manual_gray.mean(axis=0)
+
+    profile = screenshot.stripe_profile_from_screenshot(base, p1, p2, 4, blur_sigma_px=0.0)
+    assert_allclose(profile, manual_profile, atol=1e-6)
+
+
+def test_gaussian_blur_numpy_smooths_values() -> None:
+    rng = np.random.default_rng(1234)
+    data = rng.normal(size=(8, 6))
+    sigma = 1.35
+
+    blurred = screenshot._gaussian_blur_numpy(data, sigma)  # type: ignore[attr-defined]
+    assert blurred.shape == data.shape
+    assert np.var(blurred) < np.var(data)
+    assert abs(float(blurred.mean() - data.mean())) < 0.1
+    assert float(blurred.min()) >= float(data.min())
+    assert float(blurred.max()) <= float(data.max())
+
+
+def test_extract_aligned_stripe_rejects_short_line() -> None:
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    with pytest.raises(ValueError):
+        screenshot.extract_aligned_stripe(img, (1.0, 1.0), (1.5, 1.5), 3)

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,6 @@ source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "opencv-python-headless" },
     { name = "pyside6" },
 ]
 
@@ -87,7 +86,6 @@ test = [
 requires-dist = [
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "numpy", specifier = ">=1.25" },
-    { name = "opencv-python-headless", specifier = ">=4.9" },
     { name = "pyinstaller", marker = "extra == 'dev'", specifier = ">=6.14" },
     { name = "pyside6", specifier = ">=6.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3" },
@@ -294,24 +292,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/57/62/208293d7d6b2a8998a4a1f23ac758648c3c32182d4ce4346062018362e29/numpy-2.3.3-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8596ba2f8af5f93b01d97563832686d20206d303024777f6dfc2e7c7c3f1850e", size = 14420354, upload-time = "2025-09-09T15:58:52.704Z" },
     { url = "https://files.pythonhosted.org/packages/ed/0c/8e86e0ff7072e14a71b4c6af63175e40d1e7e933ce9b9e9f765a95b4e0c3/numpy-2.3.3-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e1ec5615b05369925bd1125f27df33f3b6c8bc10d788d5999ecd8769a1fa04db", size = 16760413, upload-time = "2025-09-09T15:58:55.027Z" },
     { url = "https://files.pythonhosted.org/packages/af/11/0cc63f9f321ccf63886ac203336777140011fb669e739da36d8db3c53b98/numpy-2.3.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2e267c7da5bf7309670523896df97f93f6e469fb931161f483cd6882b3b1a5dc", size = 12971844, upload-time = "2025-09-09T15:58:57.359Z" },
-]
-
-[[package]]
-name = "opencv-python-headless"
-version = "4.11.0.86"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/53/2c50afa0b1e05ecdb4603818e85f7d174e683d874ef63a6abe3ac92220c8/opencv_python_headless-4.11.0.86-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:48128188ade4a7e517237c8e1e11a9cdf5c282761473383e77beb875bb1e61ca", size = 37326460, upload-time = "2025-01-16T13:52:57.015Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/43/68555327df94bb9b59a1fd645f63fafb0762515344d2046698762fc19d58/opencv_python_headless-4.11.0.86-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:a66c1b286a9de872c343ee7c3553b084244299714ebb50fbdcd76f07ebbe6c81", size = 56723330, upload-time = "2025-01-16T13:55:45.731Z" },
-    { url = "https://files.pythonhosted.org/packages/45/be/1438ce43ebe65317344a87e4b150865c5585f4c0db880a34cdae5ac46881/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6efabcaa9df731f29e5ea9051776715b1bdd1845d7c9530065c7951d2a2899eb", size = 29487060, upload-time = "2025-01-16T13:51:59.625Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/5c/c139a7876099916879609372bfa513b7f1257f7f1a908b0bdc1c2328241b/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e0a27c19dd1f40ddff94976cfe43066fbbe9dfbb2ec1907d66c19caef42a57b", size = 49969856, upload-time = "2025-01-16T13:53:29.654Z" },
-    { url = "https://files.pythonhosted.org/packages/95/dd/ed1191c9dc91abcc9f752b499b7928aacabf10567bb2c2535944d848af18/opencv_python_headless-4.11.0.86-cp37-abi3-win32.whl", hash = "sha256:f447d8acbb0b6f2808da71fddd29c1cdd448d2bc98f72d9bb78a7a898fc9621b", size = 29324425, upload-time = "2025-01-16T13:52:49.048Z" },
-    { url = "https://files.pythonhosted.org/packages/86/8a/69176a64335aed183529207ba8bc3d329c2999d852b4f3818027203f50e6/opencv_python_headless-4.11.0.86-cp37-abi3-win_amd64.whl", hash = "sha256:6c304df9caa7a6a5710b91709dd4786bf20a74d57672b3c31f7033cc638174ca", size = 39402386, upload-time = "2025-01-16T13:52:56.418Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- drop the optional OpenCV extra and rework the screenshot helpers to use a pure NumPy pipeline with an internal Gaussian blur implementation
- add regression tests that cover the new conversion and smoothing paths exercised by the OpenCV-free code
- enhance the PyInstaller build helper to prune additional Qt assets and emit a post-build size breakdown so the largest bundled components are easy to inspect

## Testing
- uv run --group test pytest
- uv run python scripts/build_exe.py

------
https://chatgpt.com/codex/tasks/task_e_68c9833b94108325b955fbc603bd626a