### PR TITLE
Document no-future-annotations policy in AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Running the GUI integration tests requires the system packages `libgl1`, `libegl1`, and `libxkbcommon-x11-0` to satisfy Qt's OpenGL dependencies.
 - Install these packages in CI or local environments before executing `uv run pytest` or launching the packaged executable tests.
+- Do not add `from __future__ import annotations`; the project targets Python 3.10+ and relies on native postponed evaluation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,13 @@ test = [
     "scipy==1.15.3",
     "hypothesis>=6.100",
     "tomli>=2.0.1",
+    "black==24.10.0",
+    "flake8==7.1.1",
+    "flake8-docstrings==1.7.0",
+    "flake8-isort==6.1.2",
+    "flake8-noqa==1.4.0",
+    "isort==5.13.2",
+    "mypy==1.12.0",
 ]
 
 [project.optional-dependencies]
@@ -32,6 +39,13 @@ dev = [
     "scipy==1.15.3",
     "hypothesis>=6.100",
     "tomli>=2.0.1",
+    "black==24.10.0",
+    "flake8==7.1.1",
+    "flake8-docstrings==1.7.0",
+    "flake8-isort==6.1.2",
+    "flake8-noqa==1.4.0",
+    "isort==5.13.2",
+    "mypy==1.12.0",
 ]
 
 [project.scripts]
@@ -52,3 +66,55 @@ root = "."
 
 [tool.how-many]
 scipy-reference-version = "1.15.3"
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+sections = ["STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
+no_lines_before = "LOCALFOLDER"
+py_version = 310
+atomic = true
+quiet = true
+force_sort_within_sections = true
+group_by_package = true
+remove_redundant_aliases = true
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+warn_unused_ignores = true
+warn_unreachable = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+no_implicit_optional = true
+warn_redundant_casts = true
+implicit_reexport = true
+exclude = "venv|\\.venv|\\.tox|build|dist"
+
+[tool.flake8]
+max-line-length = 88
+max-complexity = 18
+select = ["C", "D", "E", "F", "I", "N", "W", "B", "B950"]
+ignore = ["E203", "E501", "W503", "W191", "E126", "E128", "E701"]
+per-file-ignores = [
+    "./docs/conf.py:E101",
+    "./tests/*.py:N803,D102,D107",
+]
+exclude = [
+    ".eggs",
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".tox",
+    "__pycache__",
+    "build",
+    "dist",
+    "venv",
+    ".venv",
+]

--- a/scripts/build_exe.py
+++ b/scripts/build_exe.py
@@ -2,12 +2,13 @@
 
 import json
 import os
+from pathlib import Path
 import re
 import subprocess
 import sys
-from pathlib import Path
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from textwrap import dedent
+
 import setuptools_scm
 
 BASE_DIR = Path(__file__).resolve().parent.parent

--- a/src/how_many/__init__.py
+++ b/src/how_many/__init__.py
@@ -1,7 +1,5 @@
 """how_many package exposing a lazy ``main`` entry point."""
 
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 from ._version import get_version

--- a/src/how_many/__main__.py
+++ b/src/how_many/__main__.py
@@ -1,9 +1,6 @@
 """Module entry point allowing ``python -m how_many``."""
 
-from __future__ import annotations
-
 from .app import main
-
 
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/src/how_many/_version.py
+++ b/src/how_many/_version.py
@@ -1,14 +1,11 @@
 """Minimal version helper for the how_many application."""
 
-from __future__ import annotations
-
 import json
-import pkgutil
-import sys
 from os import PathLike
 from pathlib import Path
+import pkgutil
+import sys
 from typing import Iterable
-
 
 PACKAGE_NAME = "how_many"
 VERSION_FILENAME = "version.json"
@@ -22,19 +19,19 @@ def get_embedded_path(name: str | PathLike[str]) -> Path:
 
 
 def get_version() -> str:
-	"""
-	Get version for application.
+    """
+    Get version for application.
 
-	:return: Version number.
-	"""
-	if getattr(sys, "frozen", False):  # *.exe
-		with open(get_embedded_path("version.json"), "r") as f:
-			version = str(json.load(f)["version"])
-	else:  # dev
-		import setuptools_scm  # type: ignore[import-untyped]
+    :return: Version number.
+    """
+    if getattr(sys, "frozen", False):  # *.exe
+        with open(get_embedded_path("version.json"), "r") as f:
+            version = str(json.load(f)["version"])
+    else:  # dev
+        import setuptools_scm  # type: ignore[import-untyped]
 
-		version = setuptools_scm.get_version()
-	return version
+        version = setuptools_scm.get_version()
+    return version
 
 
 __all__ = ["get_version", "get_embedded_path"]

--- a/src/how_many/analysis/__init__.py
+++ b/src/how_many/analysis/__init__.py
@@ -1,13 +1,13 @@
 """Core analysis routines used by the how_many overlay."""
 
+from ..models import Suggestion
 from .core import estimate_counts_from_profile
-from .peaks_detrend import find_peaks, detrend
+from .peaks_detrend import detrend, find_peaks
 from .screenshot import (
     estimate_counts_from_screenshot,
     extract_aligned_stripe,
     stripe_profile_from_screenshot,
 )
-from ..models import Suggestion
 
 __all__ = [
     "estimate_counts_from_profile",

--- a/src/how_many/analysis/core.py
+++ b/src/how_many/analysis/core.py
@@ -1,14 +1,12 @@
 """Spectral and autocorrelation based counting helpers."""
 
-from __future__ import annotations
-
 from typing import Dict, List
 
 import numpy as np
 
 from ..models import Suggestion
 from ..utils import clamp
-from .peaks_detrend import find_peaks, detrend
+from .peaks_detrend import detrend, find_peaks
 
 
 def _rank_and_cap(

--- a/src/how_many/analysis/peaks_detrend.py
+++ b/src/how_many/analysis/peaks_detrend.py
@@ -10,9 +10,10 @@ behavioural parity within the how_many project.
 """
 
 import math
-import warnings
-import numpy as np
 from typing import Literal
+import warnings
+
+import numpy as np
 
 SCIPY_REFERENCE_VERSION = "1.15.3"
 

--- a/src/how_many/analysis/screenshot.py
+++ b/src/how_many/analysis/screenshot.py
@@ -1,9 +1,7 @@
 """Helpers for deriving stripe profiles directly from screenshot imagery."""
 
-from __future__ import annotations
-from typing import List, Tuple
-
 import math
+from typing import List, Tuple
 
 import numpy as np
 
@@ -14,7 +12,6 @@ except Exception:  # pragma: no cover - we intentionally support running without
 
 from ..models import Suggestion
 from .core import estimate_counts_from_profile
-
 
 Point = Tuple[float, float]
 
@@ -101,7 +98,9 @@ def _gaussian_blur_numpy(gray: np.ndarray, sigma: float) -> np.ndarray:
     kernel /= float(np.sum(kernel))
 
     def convolve_axis(data: np.ndarray, axis: int) -> np.ndarray:
-        return np.apply_along_axis(lambda m: np.convolve(m, kernel, mode="same"), axis, data)
+        return np.apply_along_axis(
+            lambda m: np.convolve(m, kernel, mode="same"), axis, data
+        )
 
     blurred = convolve_axis(gray, axis=0)
     blurred = convolve_axis(blurred, axis=1)
@@ -210,7 +209,9 @@ def stripe_profile_from_screenshot(
             ksize = max(3, int(2 * radius + 1))
             gray = cv2.GaussianBlur(gray, (ksize, ksize), float(blur_sigma_px))
         else:
-            gray = _gaussian_blur_numpy(gray.astype(np.float64, copy=False), float(blur_sigma_px))
+            gray = _gaussian_blur_numpy(
+                gray.astype(np.float64, copy=False), float(blur_sigma_px)
+            )
 
     profile = np.mean(gray, axis=0)
     return profile.astype(np.float64, copy=False)
@@ -234,9 +235,7 @@ def estimate_counts_from_screenshot(
         stripe_width_px,
         blur_sigma_px=blur_sigma_px,
     )
-    suggestions = estimate_counts_from_profile(
-        profile, max_candidates=max_candidates
-    )
+    suggestions = estimate_counts_from_profile(profile, max_candidates=max_candidates)
     return profile, suggestions
 
 

--- a/src/how_many/app.py
+++ b/src/how_many/app.py
@@ -1,17 +1,14 @@
 """Qt application entry point for the how_many overlay tool."""
 
-from __future__ import annotations
-
+import math
 import os
-import traceback
 from pathlib import Path
+import sys
+import traceback
 from typing import Callable, List, Optional
 
-import math
-import sys
-
+from PySide6 import QtCore, QtGui, QtTest, QtWidgets
 import numpy as np
-from PySide6 import QtCore, QtGui, QtWidgets, QtTest
 
 APP_VERSION: str
 
@@ -21,7 +18,6 @@ if __package__ in (None, ""):
         sys.path.insert(0, str(PACKAGE_ROOT))
 
     import how_many as _pkg
-
     from how_many.analysis import (
         estimate_counts_from_profile,
         stripe_profile_from_screenshot,
@@ -759,7 +755,9 @@ class MainController(QtCore.QObject):
         except OSError:
             pass
 
-    def _selftest_finish(self, *, success: bool, exit_code: int, detail: str = "") -> None:
+    def _selftest_finish(
+        self, *, success: bool, exit_code: int, detail: str = ""
+    ) -> None:
         if not self._selftest_active or self._selftest_exit_done:
             return
         self._selftest_exit_done = True

--- a/src/how_many/models.py
+++ b/src/how_many/models.py
@@ -1,11 +1,8 @@
 """Dataclasses describing configuration and analysis results for how_many."""
 
-from __future__ import annotations
-
-from dataclasses import dataclass, field, asdict
-from typing import Dict
-
+from dataclasses import asdict, dataclass, field
 import json
+from typing import Dict
 
 
 @dataclass

--- a/src/how_many/utils/geometry.py
+++ b/src/how_many/utils/geometry.py
@@ -1,12 +1,12 @@
 """Geometry helpers used throughout the UI and analysis layers."""
 
-from __future__ import annotations
-
 import math
 from typing import Tuple
 
 
-def rotate_point(x: float, y: float, cx: float, cy: float, angle_deg: float) -> Tuple[float, float]:
+def rotate_point(
+    x: float, y: float, cx: float, cy: float, angle_deg: float
+) -> Tuple[float, float]:
     """Rotate a point around ``(cx, cy)`` by ``angle_deg`` degrees."""
 
     theta = math.radians(angle_deg)

--- a/src/how_many/utils/qt.py
+++ b/src/how_many/utils/qt.py
@@ -1,9 +1,7 @@
 """Qt helper utilities."""
 
-from __future__ import annotations
-
-import numpy as np
 from PySide6 import QtGui
+import numpy as np
 
 
 def qpixmap_to_bgr(pix: QtGui.QPixmap) -> np.ndarray:

--- a/tests/test_auto_analyze_dots.py
+++ b/tests/test_auto_analyze_dots.py
@@ -1,16 +1,14 @@
 """Regression tests for auto-analysis using the screenshot helpers."""
 
-from __future__ import annotations
-
 import math
 from typing import Tuple
 
+from hypothesis import given, settings
+from hypothesis import strategies as st
 import numpy as np
 import pytest
-from hypothesis import given, settings, strategies as st
 
 from how_many.analysis import estimate_counts_from_screenshot
-
 
 STRIPE_WIDTH_PX = 28
 SPACING_PX = 20.0
@@ -100,7 +98,9 @@ def test_estimate_counts_snap_angles(angle_deg: float) -> None:
     assert best.confidence > 0.75
 
 
-angles = st.floats(min_value=0.0, max_value=360.0, allow_nan=False, allow_infinity=False)
+angles = st.floats(
+    min_value=0.0, max_value=360.0, allow_nan=False, allow_infinity=False
+)
 dot_counts = st.integers(min_value=2, max_value=100)
 
 
@@ -109,7 +109,9 @@ dot_counts = st.integers(min_value=2, max_value=100)
 def test_estimate_counts_random_angle(angle_deg: float, num_dots: int) -> None:
     """Any angle between 0° and 360° should recover the dot count."""
 
-    screenshot, p1, p2 = _synthetic_dot_screenshot(num_dots=num_dots, angle_deg=angle_deg)
+    screenshot, p1, p2 = _synthetic_dot_screenshot(
+        num_dots=num_dots, angle_deg=angle_deg
+    )
     _, suggestions = estimate_counts_from_screenshot(
         screenshot,
         p1,
@@ -130,7 +132,9 @@ def test_estimate_counts_random_angle(angle_deg: float, num_dots: int) -> None:
 def test_estimate_counts_reverse_endpoints(angle_deg: float, num_dots: int) -> None:
     """Reversing the endpoints should not change the recovered dot count."""
 
-    screenshot, p1, p2 = _synthetic_dot_screenshot(num_dots=num_dots, angle_deg=angle_deg)
+    screenshot, p1, p2 = _synthetic_dot_screenshot(
+        num_dots=num_dots, angle_deg=angle_deg
+    )
 
     _, forward_suggestions = estimate_counts_from_screenshot(
         screenshot,

--- a/tests/test_executable_selftest.py
+++ b/tests/test_executable_selftest.py
@@ -1,13 +1,11 @@
 """End-to-end test for the packaged how_many executable."""
 
-from __future__ import annotations
-
 import ctypes
 import ctypes.util
 import os
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 from typing import Iterable
 
 import pytest

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,63 @@
+"""Formatting validation tests.
+
+These tests ensure that the codebase complies with the configured
+formatting tools. They provide fast feedback when formatting drifts from
+the expected style defined in ``pyproject.toml``.
+"""
+
+from pathlib import Path
+import subprocess
+from typing import Iterable, Sequence
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _run_command(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Execute *command* from the repository root.
+
+    Args:
+        command: The command line to execute.
+
+    Returns:
+        The :class:`~subprocess.CompletedProcess` describing the completed
+        command.
+    """
+
+    return subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _format_failure_message(result: subprocess.CompletedProcess[str]) -> str:
+    """Generate a helpful error message for a failed formatting command."""
+
+    details: Iterable[str] = (
+        "Formatting command failed.",
+        f"Command: {' '.join(result.args)}",
+        "--- stdout ---",
+        result.stdout.strip(),
+        "--- stderr ---",
+        result.stderr.strip(),
+    )
+    return "\n".join(filter(None, details))
+
+
+@pytest.mark.parametrize(
+    ("description", "command"),
+    (
+        ("black", ["python", "-m", "black", "--check", "src", "tests", "scripts"]),
+        ("isort", ["python", "-m", "isort", "--check-only", "src", "tests", "scripts"]),
+    ),
+)
+def test_formatting_commands(description: str, command: Sequence[str]) -> None:
+    """Ensure that the configured formatting commands succeed."""
+
+    result = _run_command(command)
+    if result.returncode != 0:
+        pytest.fail(_format_failure_message(result))

--- a/tests/test_peaks_detrend.py
+++ b/tests/test_peaks_detrend.py
@@ -10,9 +10,9 @@ behaviour.
 """
 
 import importlib.resources as resources
+from pathlib import Path
 import shutil
 import sys
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -46,9 +46,7 @@ def ensure_expected_scipy_version():
     with (ROOT / "pyproject.toml").open("rb") as fh:
         config = tomllib.load(fh)
     configured_version = (
-        config.get("tool", {})
-        .get("how-many", {})
-        .get("scipy-reference-version")
+        config.get("tool", {}).get("how-many", {}).get("scipy-reference-version")
     )
     if configured_version != EXPECTED_SCIPY_VERSION:
         pytest.fail(

--- a/uv.lock
+++ b/uv.lock
@@ -32,6 +32,52 @@ wheels = [
 ]
 
 [[package]]
+name = "black"
+version = "24.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813, upload-time = "2024-10-07T19:20:50.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/f3/465c0eb5cddf7dbbfe1fecd9b875d1dcf51b88923cd2c1d7e9ab95c6336b/black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812", size = 1623211, upload-time = "2024-10-07T19:26:12.43Z" },
+    { url = "https://files.pythonhosted.org/packages/df/57/b6d2da7d200773fdfcc224ffb87052cf283cec4d7102fab450b4a05996d8/black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea", size = 1457139, upload-time = "2024-10-07T19:25:06.453Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c5/9023b7673904a5188f9be81f5e129fff69f51f5515655fbd1d5a4e80a47b/black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f", size = 1753774, upload-time = "2024-10-07T19:23:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/32/df7f18bd0e724e0d9748829765455d6643ec847b3f87e77456fc99d0edab/black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e", size = 1414209, upload-time = "2024-10-07T19:24:42.54Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/cc/7496bb63a9b06a954d3d0ac9fe7a73f3bf1cd92d7a58877c27f4ad1e9d41/black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad", size = 1607468, upload-time = "2024-10-07T19:26:14.966Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/e3/69a738fb5ba18b5422f50b4f143544c664d7da40f09c13969b2fd52900e0/black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50", size = 1437270, upload-time = "2024-10-07T19:25:24.291Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/9b/2db8045b45844665c720dcfe292fdaf2e49825810c0103e1191515fc101a/black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392", size = 1737061, upload-time = "2024-10-07T19:23:52.18Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/95/17d4a09a5be5f8c65aa4a361444d95edc45def0de887810f508d3f65db7a/black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175", size = 1423293, upload-time = "2024-10-07T19:24:41.7Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/bf74c71f592bcd761610bbf67e23e6a3cff824780761f536512437f1e655/black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3", size = 1644256, upload-time = "2024-10-07T19:27:53.355Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ea/a77bab4cf1887f4b2e0bce5516ea0b3ff7d04ba96af21d65024629afedb6/black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65", size = 1448534, upload-time = "2024-10-07T19:26:44.953Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3e/443ef8bc1fbda78e61f79157f303893f3fddf19ca3c8989b163eb3469a12/black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f", size = 1761892, upload-time = "2024-10-07T19:24:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/52/93/eac95ff229049a6901bc84fec6908a5124b8a0b7c26ea766b3b8a5debd22/black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8", size = 1434796, upload-time = "2024-10-07T19:25:06.239Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a0/a993f58d4ecfba035e61fca4e9f64a2ecae838fc9f33ab798c62173ed75c/black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981", size = 1643986, upload-time = "2024-10-07T19:28:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d5/602d0ef5dfcace3fb4f79c436762f130abd9ee8d950fa2abdbf8bbc555e0/black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b", size = 1448085, upload-time = "2024-10-07T19:28:12.093Z" },
+    { url = "https://files.pythonhosted.org/packages/47/6d/a3a239e938960df1a662b93d6230d4f3e9b4a22982d060fc38c42f45a56b/black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2", size = 1760928, upload-time = "2024-10-07T19:24:15.233Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/cf/af018e13b0eddfb434df4d9cd1b2b7892bab119f7a20123e93f6910982e8/black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b", size = 1436875, upload-time = "2024-10-07T19:24:42.762Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/a7/4b27c50537ebca8bec139b872861f9d2bf501c5ec51fcf897cb924d9e264/black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d", size = 206898, upload-time = "2024-10-07T19:20:48.317Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -53,6 +99,59 @@ wheels = [
 ]
 
 [[package]]
+name = "flake8"
+version = "7.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mccabe" },
+    { name = "pycodestyle" },
+    { name = "pyflakes" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/72/e8d66150c4fcace3c0a450466aa3480506ba2cae7b61e100a2613afc3907/flake8-7.1.1.tar.gz", hash = "sha256:049d058491e228e03e67b390f311bbf88fce2dbaa8fa673e7aea87b7198b8d38", size = 48054, upload-time = "2024-08-04T20:32:44.311Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/42/65004373ac4617464f35ed15931b30d764f53cdd30cc78d5aea349c8c050/flake8-7.1.1-py2.py3-none-any.whl", hash = "sha256:597477df7860daa5aa0fdd84bf5208a043ab96b8e96ab708770ae0364dd03213", size = 57731, upload-time = "2024-08-04T20:32:42.661Z" },
+]
+
+[[package]]
+name = "flake8-docstrings"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flake8" },
+    { name = "pydocstyle" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/24/f839e3a06e18f4643ccb81370909a497297909f15106e6af2fecdef46894/flake8_docstrings-1.7.0.tar.gz", hash = "sha256:4c8cc748dc16e6869728699e5d0d685da9a10b0ea718e090b1ba088e67a941af", size = 5995, upload-time = "2023-01-25T14:27:13.903Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/7d/76a278fa43250441ed9300c344f889c7fb1817080c8fb8996b840bf421c2/flake8_docstrings-1.7.0-py2.py3-none-any.whl", hash = "sha256:51f2344026da083fc084166a9353f5082b01f72901df422f74b4d953ae88ac75", size = 4994, upload-time = "2023-01-25T14:27:12.32Z" },
+]
+
+[[package]]
+name = "flake8-isort"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flake8" },
+    { name = "isort" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/ea/2f2662d4fefa6ab335c7119cb28e5bc57c935a86a69a7f72df3ea5fe7b2c/flake8_isort-6.1.2.tar.gz", hash = "sha256:9d0452acdf0e1cd6f2d6848e3605e66b54d920e73471fb4744eef0f93df62d5d", size = 17756, upload-time = "2025-01-29T12:29:25.753Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/10/295e982874f2a94f309baf7c45f852a191c87d59bd846b1701332303783f/flake8_isort-6.1.2-py3-none-any.whl", hash = "sha256:549197dedf0273502fb74f04c080beed9e62a7eb70244610413d27052e78bd3b", size = 18385, upload-time = "2025-01-29T12:29:23.46Z" },
+]
+
+[[package]]
+name = "flake8-noqa"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flake8" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/d0/88b930e9da2f333c71474a2d8207954178d71724a6673a111d9117aff1c6/flake8-noqa-1.4.0.tar.gz", hash = "sha256:771765ab27d1efd157528379acd15131147f9ae578a72d17fb432ca197881243", size = 27077, upload-time = "2024-01-07T22:35:50.584Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/ec/0eab800b28f3c2d1eeae2561eda4962ca5291e97668728405f9fddfdc768/flake8_noqa-1.4.0-py3-none-any.whl", hash = "sha256:4465e16a19be433980f6f563d05540e2e54797eb11facb9feb50fed60624dc45", size = 24819, upload-time = "2024-01-07T22:35:48.805Z" },
+]
+
+[[package]]
 name = "how-many"
 source = { editable = "." }
 dependencies = [
@@ -63,7 +162,14 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "black" },
+    { name = "flake8" },
+    { name = "flake8-docstrings" },
+    { name = "flake8-isort" },
+    { name = "flake8-noqa" },
     { name = "hypothesis" },
+    { name = "isort" },
+    { name = "mypy" },
     { name = "pyinstaller" },
     { name = "pytest" },
     { name = "scipy" },
@@ -77,7 +183,14 @@ build = [
     { name = "setuptools-scm" },
 ]
 test = [
+    { name = "black" },
+    { name = "flake8" },
+    { name = "flake8-docstrings" },
+    { name = "flake8-isort" },
+    { name = "flake8-noqa" },
     { name = "hypothesis" },
+    { name = "isort" },
+    { name = "mypy" },
     { name = "pytest" },
     { name = "scipy" },
     { name = "tomli" },
@@ -85,7 +198,14 @@ test = [
 
 [package.metadata]
 requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = "==24.10.0" },
+    { name = "flake8", marker = "extra == 'dev'", specifier = "==7.1.1" },
+    { name = "flake8-docstrings", marker = "extra == 'dev'", specifier = "==1.7.0" },
+    { name = "flake8-isort", marker = "extra == 'dev'", specifier = "==6.1.2" },
+    { name = "flake8-noqa", marker = "extra == 'dev'", specifier = "==1.4.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.100" },
+    { name = "isort", marker = "extra == 'dev'", specifier = "==5.13.2" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = "==1.12.0" },
     { name = "numpy", specifier = ">=1.25" },
     { name = "pyinstaller", marker = "extra == 'dev'", specifier = ">=6.14" },
     { name = "pyside6", specifier = ">=6.5" },
@@ -102,7 +222,14 @@ build = [
     { name = "setuptools-scm", specifier = ">=8" },
 ]
 test = [
+    { name = "black", specifier = "==24.10.0" },
+    { name = "flake8", specifier = "==7.1.1" },
+    { name = "flake8-docstrings", specifier = "==1.7.0" },
+    { name = "flake8-isort", specifier = "==6.1.2" },
+    { name = "flake8-noqa", specifier = "==1.4.0" },
     { name = "hypothesis", specifier = ">=6.100" },
+    { name = "isort", specifier = "==5.13.2" },
+    { name = "mypy", specifier = "==1.12.0" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "scipy", specifier = "==1.15.3" },
     { name = "tomli", specifier = ">=2.0.1" },
@@ -132,6 +259,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "5.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/87/f9/c1eb8635a24e87ade2efce21e3ce8cd6b8630bb685ddc9cdaca1349b2eb5/isort-5.13.2.tar.gz", hash = "sha256:48fdfcb9face5d58a4f6dde2e72a1fb8dcaf8ab26f95ab49fab84c2ddefb0109", size = 175303, upload-time = "2023-12-13T20:37:26.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/b3/8def84f539e7d2289a02f0524b944b15d7c75dab7628bedf1c4f0992029c/isort-5.13.2-py3-none-any.whl", hash = "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6", size = 92310, upload-time = "2023-12-13T20:37:23.244Z" },
+]
+
+[[package]]
 name = "macholib"
 version = "1.16.3"
 source = { registry = "https://pypi.org/simple" }
@@ -141,6 +277,58 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/ee/af1a3842bdd5902ce133bd246eb7ffd4375c38642aeb5dc0ae3a0329dfa2/macholib-1.16.3.tar.gz", hash = "sha256:07ae9e15e8e4cd9a788013d81f5908b3609aa76f9b1421bae9c4d7606ec86a30", size = 59309, upload-time = "2023-09-25T09:10:16.155Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/5d/c059c180c84f7962db0aeae7c3b9303ed1d73d76f2bfbc32bc231c8be314/macholib-1.16.3-py2.py3-none-any.whl", hash = "sha256:0e315d7583d38b8c77e815b1ecbdbf504a8258d8b3e17b61165c6feb60d18f2c", size = 38094, upload-time = "2023-09-25T09:10:14.188Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
+]
+
+[[package]]
+name = "mypy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/70/196a3339459fe22296ac9a883bbd998fcaf0db3e8d9a54cf4f53b722cad4/mypy-1.12.0.tar.gz", hash = "sha256:65a22d87e757ccd95cbbf6f7e181e6caa87128255eb2b6be901bb71b26d8a99d", size = 3149879, upload-time = "2024-10-14T11:27:30.407Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/6d/9751ed6d77b42a5d704224fbadf6f1a18b5ab655c012d17bc8af819a7f06/mypy-1.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4397081e620dc4dc18e2f124d5e1d2c288194c2c08df6bdb1db31c38cd1fe1ed", size = 11017763, upload-time = "2024-10-14T11:25:33.306Z" },
+    { url = "https://files.pythonhosted.org/packages/74/03/5fa6824555460f74873a414c7f42332c219fdfcfbd63b55b2442794b634b/mypy-1.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:684a9c508a283f324804fea3f0effeb7858eb03f85c4402a967d187f64562469", size = 10181032, upload-time = "2024-10-14T11:25:59.492Z" },
+    { url = "https://files.pythonhosted.org/packages/89/56/20d3136d6904c369422423d267c5ceb312487586cdd81e90bf7e237b67e7/mypy-1.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cabe4cda2fa5eca7ac94854c6c37039324baaa428ecbf4de4567279e9810f9e", size = 12587243, upload-time = "2024-10-14T11:26:16.827Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cb/64043dec34fbcecaced207b077b8e5041e263da43003cc6309c90bc5e26e/mypy-1.12.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:060a07b10e999ac9e7fa249ce2bdcfa9183ca2b70756f3bce9df7a92f78a3c0a", size = 13105170, upload-time = "2024-10-14T11:24:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/59/e89758d47412ec6bd7a2fd9cae8074b7ffb2acee40456a4efbedd42e2dfd/mypy-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:0eff042d7257f39ba4ca06641d110ca7d2ad98c9c1fb52200fe6b1c865d360ff", size = 9633620, upload-time = "2024-10-14T11:26:32.38Z" },
+    { url = "https://files.pythonhosted.org/packages/21/68/9098b11b5c4371793237c7a2c5e9415ece358bed97bc849e9191d38c66b5/mypy-1.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4b86de37a0da945f6d48cf110d5206c5ed514b1ca2614d7ad652d4bf099c7de7", size = 10940151, upload-time = "2024-10-14T11:27:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/11/14a4373e5da6636fc4c8475cabe65084ff640528bc6c4f426d9c992736a9/mypy-1.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:20c7c5ce0c1be0b0aea628374e6cf68b420bcc772d85c3c974f675b88e3e6e57", size = 10107645, upload-time = "2024-10-14T11:24:47.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/07/b73faeeaadabb5aab23195bfd828392c9a5e21e7b8cdf8369a2546e00ce6/mypy-1.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a64ee25f05fc2d3d8474985c58042b6759100a475f8237da1f4faf7fcd7e6309", size = 12504561, upload-time = "2024-10-14T11:23:34.119Z" },
+    { url = "https://files.pythonhosted.org/packages/78/70/c35608364f9cdf97c048f0240be4d06d3baadede2767a5fbf60aad7c64f3/mypy-1.12.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:faca7ab947c9f457a08dcb8d9a8664fd438080e002b0fa3e41b0535335edcf7f", size = 12983108, upload-time = "2024-10-14T11:25:42.849Z" },
+    { url = "https://files.pythonhosted.org/packages/74/fa/e5b0d4291ed9b94075fe13a0cdd1d9f1ba9d32ea1f8e88aec2ffcd057ac3/mypy-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:5bc81701d52cc8767005fdd2a08c19980de9ec61a25dbd2a937dfb1338a826f9", size = 9629293, upload-time = "2024-10-14T11:24:02.342Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c8/ef6e2a11f0de6cf4359552bf71f07a89f302d27e25bf4c9761649bf1b5a8/mypy-1.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8462655b6694feb1c99e433ea905d46c478041a8b8f0c33f1dab00ae881b2164", size = 11072079, upload-time = "2024-10-14T11:26:56.809Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e7/1f9ba3965c3c445d863290d3f8521a7a726b878784f5ad642e82c038261f/mypy-1.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:923ea66d282d8af9e0f9c21ffc6653643abb95b658c3a8a32dca1eff09c06475", size = 10071930, upload-time = "2024-10-14T11:23:54.807Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/11/c84fb4c3a42ffd460c2a9b27105fbd538ec501e5aa34671fd3d14a1b94ba/mypy-1.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ebf9e796521f99d61864ed89d1fb2926d9ab6a5fab421e457cd9c7e4dd65aa9", size = 12588227, upload-time = "2024-10-14T11:25:15.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ad/b55d070d2001e47c4c6c7d00b13f8dafb16b74db5a99904a183e3c0a3bd6/mypy-1.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:e478601cc3e3fa9d6734d255a59c7a2e5c2934da4378f3dd1e3411ea8a248642", size = 13037186, upload-time = "2024-10-14T11:23:43.961Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c8/5fc9ef8d3ea89490939ecdfea7a84cede31a69534d468c34807941f5a79f/mypy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:c72861b7139a4f738344faa0e150834467521a3fba42dc98264e5aa9507dd601", size = 9727738, upload-time = "2024-10-14T11:23:25.353Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/07/0df1b099a4a725e61782f7d9a34947fc93be688f9dfa011d86e411b2f036/mypy-1.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52b9e1492e47e1790360a43755fa04101a7ac72287b1a53ce817f35899ba0521", size = 11071648, upload-time = "2024-10-14T11:23:16.875Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/60/2a8bdb4f822bcdb0fa4599b83c1ae9f9ab0e10c1bee262dd9c1ff4607b12/mypy-1.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:48d3e37dd7d9403e38fa86c46191de72705166d40b8c9f91a3de77350daa0893", size = 10065760, upload-time = "2024-10-14T11:26:48.763Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d9/065ec6bd21a0ae14b520574d531dc1aa23fdc30fd276dea25f71945172d2/mypy-1.12.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f106db5ccb60681b622ac768455743ee0e6a857724d648c9629a9bd2ac3f721", size = 12584005, upload-time = "2024-10-14T11:26:41.341Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a8/31449fc5698d1a55062614790a885128e3b2a21de0f82a426942a5ae6a00/mypy-1.12.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:233e11b3f73ee1f10efada2e6da0f555b2f3a5316e9d8a4a1224acc10e7181d3", size = 13030941, upload-time = "2024-10-14T11:24:11.772Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/8e/2347814cffccfb52fc02cbe457ae4a3fb5b660c5b361cdf72374266c231b/mypy-1.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:4ae8959c21abcf9d73aa6c74a313c45c0b5a188752bf37dace564e29f06e9c1b", size = 9734383, upload-time = "2024-10-14T11:27:04.153Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fd/2cc64da1ce9fada64b5d023dfbaf763548429145d08c958c78c02876c7f6/mypy-1.12.0-py3-none-any.whl", hash = "sha256:fd313226af375d52e1e36c383f39bf3836e1f192801116b31b090dfcd3ec5266", size = 2645791, upload-time = "2024-10-14T11:24:32.06Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
 
 [[package]]
@@ -309,6 +497,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
+]
+
+[[package]]
 name = "pefile"
 version = "2023.2.7"
 source = { registry = "https://pypi.org/simple" }
@@ -318,12 +515,51 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/e8/21db9c9987b0e728855bd57bff6984f67952bea55d6f75e055c46b5383e8/platformdirs-4.4.0.tar.gz", hash = "sha256:ca753cf4d81dc309bc67b0ea38fd15dc97bc30ce419a7f58d13eb3bf14c4febf", size = 21634, upload-time = "2025-08-26T14:32:04.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/4b/2028861e724d3bd36227adfa20d3fd24c3fc6d52032f4a93c133be5d17ce/platformdirs-4.4.0-py3-none-any.whl", hash = "sha256:abd01743f24e5287cd7a5db3752faf1a2d65353f38ec26d98e25a6db65958c85", size = 18654, upload-time = "2025-08-26T14:32:02.735Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycodestyle"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/aa/210b2c9aedd8c1cbeea31a50e42050ad56187754b34eb214c46709445801/pycodestyle-2.12.1.tar.gz", hash = "sha256:6838eae08bbce4f6accd5d5572075c63626a15ee3e6f842df996bf62f6d73521", size = 39232, upload-time = "2024-08-04T20:26:54.576Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/d8/a211b3f85e99a0daa2ddec96c949cac6824bd305b040571b82a03dd62636/pycodestyle-2.12.1-py2.py3-none-any.whl", hash = "sha256:46f0fb92069a7c28ab7bb558f05bfc0110dac69a0cd23c61ea0040283a9d78b3", size = 31284, upload-time = "2024-08-04T20:26:53.173Z" },
+]
+
+[[package]]
+name = "pydocstyle"
+version = "6.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "snowballstemmer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/5c/d5385ca59fd065e3c6a5fe19f9bc9d5ea7f2509fa8c9c22fb6b2031dd953/pydocstyle-6.3.0.tar.gz", hash = "sha256:7ce43f0c0ac87b07494eb9c0b462c0b73e6ff276807f204d6b53edc72b7e44e1", size = 36796, upload-time = "2023-01-17T20:29:19.838Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/ea/99ddefac41971acad68f14114f38261c1f27dac0b3ec529824ebc739bdaa/pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019", size = 38038, upload-time = "2023-01-17T20:29:18.094Z" },
+]
+
+[[package]]
+name = "pyflakes"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/f9/669d8c9c86613c9d568757c7f5824bd3197d7b1c6c27553bc5618a27cce2/pyflakes-3.2.0.tar.gz", hash = "sha256:1c61603ff154621fb2a9172037d84dca3500def8c8b630657d1701f026f8af3f", size = 63788, upload-time = "2024-01-05T00:28:47.703Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/d7/f1b7db88d8e4417c5d47adad627a93547f44bdc9028372dbd2313f34a855/pyflakes-3.2.0-py2.py3-none-any.whl", hash = "sha256:84b5be138a2dfbb40689ca07e2152deb896a65c3a3e24c251c5c62489568074a", size = 62725, upload-time = "2024-01-05T00:28:45.903Z" },
 ]
 
 [[package]]
@@ -541,6 +777,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/c4/09e902f5612a509cef2c8712c516e4fe44f3a1ae9fcd8921baddb5e6bae4/shiboken6-6.9.2-cp39-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:a5f5985938f5acb604c23536a0ff2efb3cccb77d23da91fbaff8fd8ded3dceb4", size = 202784, upload-time = "2025-08-26T07:52:43.172Z" },
     { url = "https://files.pythonhosted.org/packages/a4/ea/a56b094a4bf6facf89f52f58e83684e168b1be08c14feb8b99969f3d4189/shiboken6-6.9.2-cp39-abi3-win_amd64.whl", hash = "sha256:68c33d565cd4732be762d19ff67dfc53763256bac413d392aa8598b524980bc4", size = 1152089, upload-time = "2025-08-26T07:52:45.162Z" },
     { url = "https://files.pythonhosted.org/packages/48/64/562a527fc55fbf41fa70dae735929988215505cb5ec0809fb0aef921d4a0/shiboken6-6.9.2-cp39-abi3-win_arm64.whl", hash = "sha256:c5b827797b3d89d9b9a3753371ff533fcd4afc4531ca51a7c696952132098054", size = 1708948, upload-time = "2025-08-26T07:52:48.016Z" },
+]
+
+[[package]]
+name = "snowballstemmer"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- document the Python 3.10 annotations policy in AGENTS.md so all contributors see it
- remove the redundant agents.txt helper file now that the guidance lives alongside other agent instructions

## Testing
- `uv run --group test pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc25e3edac8325ada379834285112e